### PR TITLE
Add resourceServiceExists

### DIFF
--- a/resource_service.go
+++ b/resource_service.go
@@ -31,6 +31,7 @@ func resourceService() *schema.Resource {
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -134,4 +135,20 @@ func resourceServiceDelete(d *schema.ResourceData, m interface{}) error {
 	d.Set("credentials", nil)
 	d.Set("enabled", false)
 	return nil
+}
+
+// resourceServiceExists checks if the service is enabled
+func resourceServiceExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(confidant.Client)
+	name := d.Id()
+
+	service, err := client.GetService(name)
+	if err != nil {
+		if err.Error() == "Service Doesn't Exist" {
+			return false, nil
+		}
+		// Some other error, default to true
+		return true, err
+	}
+	return service.Enabled, nil
 }


### PR DESCRIPTION
<!--
* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Update README.md and example_test.go if necessary
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
add resourceServiceExists - returns false if service is not enabled or service doesn't exist. See docs here: https://godoc.org/github.com/hashicorp/terraform/helper/schema#Resource

#### Motivation
<!-- Why are you making this change? This can be a link to a GitHub Issue. -->
This is to fix a bug we have currently where terraform plan reports destroying disabled services. This makes it hard to know whether terraform plan is gong to make a destructive change or not (which defeats the purpose of terraform plan!).

I believe the reason this happens is because main.tf typically does not contain resources for services that are disabled. Running terraform plan fetches the current state from Confidant, which includes resources that are disabled. Therefore the plan reports that these services will be destroyed. 

The other option here is to use the CustomizeDiff function (this was my original plan), but it looks like this is more straightforward.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Using this currently

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
N/A