### PR TITLE
Set credentials when creating a service

### DIFF
--- a/resource_service.go
+++ b/resource_service.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/stripe/go-confidant-client/confidant"
@@ -56,7 +55,7 @@ func resourceService() *schema.Resource {
 }
 
 // resourceServiceCreate calls CreateService with no credentials.
-// If the service already exists, it sets enabled to true.
+// If the service already exists, it sets enabled to true and updates the credentials.
 func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(confidant.Client)
 	name, ok := d.Get("name").(string)
@@ -72,7 +71,9 @@ func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 		if err.Error() != "Service Already Exists" {
 			return err
 		}
-		log.Println("Service already exists, setting Enabled to True")
+		if _, err = client.SetServiceCredentials(name, credentials); err != nil {
+			return err
+		}
 		_, err := client.EnableService(name)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Update README.md and example_test.go if necessary
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Changed the behavior of resourceServiceCreate - previously, if a service was already created this method would only re-enable it. Now we will also set the credentials (essentially updating the service). 

#### Motivation
<!-- Why are you making this change? This can be a link to a GitHub Issue. -->
We want to sync the secrets listed locally if we're toggling the "enabled" state.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
1. Built and installed this branch as a plugin
2. Disabled a service using the provider (which also set the credential list to empty)
3. Created it using the provider, passing in extra credentials
4. Checked the confidant UI to see that the service was enabled and had the credentials