### PR TITLE
Use Xenial in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# trusty beta image has jdk8, gcc4.8.4
-dist: trusty
+dist: xenial
 sudo: required
 # xcode8 has jdk8
 osx_image: xcode8


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Update README.md and example_test.go if necessary
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
This updates the Travis config to use Xenial rather than Trusty.

#### Motivation
<!-- Why are you making this change? This can be a link to a GitHub Issue. -->
Trusty is no longer supported.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
It looks like Travis is no longer actually enabled for this repo, so at this point this change does nothing. If we re-enable Travis, we'll check to see if this breaks any dependencies in tests. If so, I will follow up with a commit that fixes those issues.